### PR TITLE
Exported all the unexported types in utils index.d.ts (resolves#6977)

### DIFF
--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -57,7 +57,7 @@ export type PropsOf<TComponent> = TComponent extends React.ComponentType<
   : never;
 
 // the basic T-Shirt sizes xsmall through xlarge. Some places add on.
-type TShirtSizeType =
+export type TShirtSizeType =
   | 'xsmall'
   | 'small'
   | 'medium'
@@ -66,7 +66,7 @@ type TShirtSizeType =
   | string;
 
 // Extracting types for common properties among components
-type BoxSideType =
+export type BoxSideType =
   | 'top'
   | 'left'
   | 'bottom'
@@ -77,8 +77,8 @@ type BoxSideType =
   | 'vertical'
   | 'all'
   | 'between';
-type BoxSizeType = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
-type BoxStyleType =
+export type BoxSizeType = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
+export type BoxStyleType =
   | 'solid'
   | 'dashed'
   | 'dotted'
@@ -95,7 +95,7 @@ export type EdgeSizeType =
   | 'medium'
   | 'large'
   | 'xlarge';
-type EdgeType =
+export type EdgeType =
   | 'none'
   | EdgeSizeType
   | {


### PR DESCRIPTION
Export Certain Box Types in utils

#### What does this PR do?
exports some unexported box types in utils file

#### Where should the reviewer start?
src/utils/index..d.ts

#### What testing has been done on this PR?


#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
